### PR TITLE
Add support for Alphabetic combination locks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/dist
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-/dist
-/.vscode
+dist/*
+.vscode
+.clang-format
+.clangd
+.editorconfig
+.env
+.ufbt

--- a/combo_cracker.c
+++ b/combo_cracker.c
@@ -58,6 +58,23 @@ static const char gc_lock_labels_numeric[LOCK_INDEX_COUNT][3u] = {
     "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27",
     "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39",
 };
+static const char gc_resistance_labels_alpha[RESISTANCE_INDEX_COUNT][5u] = {
+    // NOTE: For whatever reason, I chose for `Y` to be equivalent to `0`
+    "Y.00", "Y.25", "Y.50", "Y.75", "A.00", "A.25", "A.50", "A.75", "B.00", "B.25", "B.50", "B.75",
+    "C.00", "C.25", "C.50", "C.75", "D.00", "D.25", "D.50", "D.75", "E.00", "E.25", "E.50", "E.75",
+    "F.00", "F.25", "F.50", "F.75", "G.00", "G.25", "G.50", "G.75", "H.00", "H.25", "H.50", "H.75",
+    "I.00", "I.25", "I.50", "I.75", "L.00", "L.25", "L.50", "L.75", "M.00", "M.25", "M.50", "M.75",
+    "N.00", "N.25", "N.50", "N.75", "O.00", "O.25", "O.50", "O.75", "P.00", "P.25", "P.50", "P.75",
+    "R.00", "R.25", "R.50", "R.75", "S.00", "S.25", "S.50", "S.75", "T.00", "T.25", "T.50", "T.75",
+    "U.00", "U.25", "U.50", "U.75", "W.00", "W.25", "W.50", "W.75",
+};
+static const char gc_lock_labels_alpha[LOCK_INDEX_COUNT][4u] = {
+    // NOTE: For whatever reason, I chose for `Y` to be equivalent to `0`
+    "Y", "Y.5", "A", "A.5", "B", "B.5", "C", "C.5", "D", "D.5", "E", "E.5", "F", "F.5",
+    "G", "G.5", "H", "H.5", "I", "I.5", "L", "L.5", "M", "M.5", "N", "N.5", "O", "O.5",
+    "P", "P.5", "R", "R.5", "S", "S.5", "T", "T.5", "U", "U.5", "W", "W.5",
+};
+
 #if 1 // pragma region // static const char gc_howto_numeric[]
 static const char gc_instructions_numeric[] =
     "How to use:\n"
@@ -122,17 +139,44 @@ typedef struct {
  */
 
 static const char* lock1_label_from_model(const ComboLockCrackerModel* model) {
-    return gc_lock_labels_numeric[model->first_lock_index];
+    switch(model->lock_type) {
+    case ComboLockTypeNumeric:
+        return gc_lock_labels_numeric[model->first_lock_index];
+    case ComboLockTypeAlphabetic:
+        return gc_lock_labels_alpha[model->first_lock_index];
+    default:
+        return "?L1?";
+    }
 }
 static const char* lock2_label_from_model(const ComboLockCrackerModel* model) {
-    return gc_lock_labels_numeric[model->second_lock_index];
+    switch(model->lock_type) {
+    case ComboLockTypeNumeric:
+        return gc_lock_labels_numeric[model->second_lock_index];
+    case ComboLockTypeAlphabetic:
+        return gc_lock_labels_alpha[model->second_lock_index];
+    default:
+        return "?L2?";
+    }
 }
 static const char* resistance_label_from_model(const ComboLockCrackerModel* model) {
-    return gc_resistance_labels_numeric[model->resistance_index];
+    switch(model->lock_type) {
+    case ComboLockTypeNumeric:
+        return gc_resistance_labels_numeric[model->resistance_index];
+    case ComboLockTypeAlphabetic:
+        return gc_resistance_labels_alpha[model->resistance_index];
+    default:
+        return "?RR?";
+    }
 }
 static const char* label_from_solution_index(const ComboLockCrackerModel* model, int index) {
-    (void)(model); // need this to swap based on current lock model
-    return gc_lock_labels_numeric[index];
+    switch(model->lock_type) {
+    case ComboLockTypeNumeric:
+        return gc_lock_labels_numeric[index];
+    case ComboLockTypeAlphabetic:
+        return gc_lock_labels_alpha[index];
+    default:
+        return "?SS?";
+    }
 }
 
 static int SolutionComparator(const ComboLockCombination* r1, const ComboLockCombination* r2) {
@@ -789,6 +833,7 @@ static ComboLockCrackerApp* combo_app_alloc() {
     view_allocate_model(app->view_cracker, ViewModelTypeLockFree, sizeof(ComboLockCrackerModel));
 
     ComboLockCrackerModel* model = view_get_model(app->view_cracker);
+    model->lock_type = ComboLockTypeAlphabetic;
     model->first_lock_index = 7;
     model->second_lock_index = 14;
     model->resistance_index = 26;

--- a/combo_cracker.c
+++ b/combo_cracker.c
@@ -99,10 +99,6 @@ typedef struct {
 
 typedef struct {
     ComboLockType lock_type;
-    int first_lock; // to be removed...
-    int second_lock; // to be removed...
-    float resistance; // to be removed...
-
     uint8_t first_lock_index; //  Index into gc_lock_string_*
     uint8_t second_lock_index; // Index into gc_lock_string_*
     uint8_t resistance_index; //  Index into gc_resistance_string_*
@@ -185,12 +181,9 @@ static void dump_state_and_combinations_to_model_result(
     written = snprintf(
         b,
         remaining_bytes,
-        "M: %d (%d), %d (%d), %.1f (%d)",
-        model->first_lock,
+        "M: %d, %d, %d",
         model->first_lock_index,
-        model->second_lock,
         model->second_lock_index,
-        (double)(model->resistance),
         model->resistance_index);
     if((written < 0) || (written >= remaining_bytes)) {
         // can't add anything more, so return.
@@ -652,16 +645,13 @@ static bool combo_view_cracker_input_callback(InputEvent* event, void* context) 
                 app->view_cracker,
                 ComboLockCrackerModel * model,
                 {
-                    if(model->selected == 0 && model->first_lock > 0) {
-                        model->first_lock--;
+                    if(model->selected == 0 && model->first_lock_index > 0) {
                         model->first_lock_index--;
                     }
-                    if(model->selected == 1 && model->second_lock > 0) {
-                        model->second_lock--;
+                    if(model->selected == 1 && model->second_lock_index > 0) {
                         model->second_lock_index--;
                     }
-                    if(model->selected == 2 && model->resistance > 0) {
-                        model->resistance -= 0.5f;
+                    if(model->selected == 2 && model->resistance_index > 0) {
                         model->resistance_index -= 1;
                     }
                 },
@@ -672,16 +662,13 @@ static bool combo_view_cracker_input_callback(InputEvent* event, void* context) 
                 app->view_cracker,
                 ComboLockCrackerModel * model,
                 {
-                    if(model->selected == 0 && model->first_lock < 39) {
-                        model->first_lock++;
+                    if(model->selected == 0 && model->first_lock_index < 39) {
                         model->first_lock_index++;
                     }
-                    if(model->selected == 1 && model->second_lock < 39) {
-                        model->second_lock++;
+                    if(model->selected == 1 && model->first_lock_index < 39) {
                         model->second_lock_index++;
                     }
-                    if(model->selected == 2 && model->resistance < 39.5f) {
-                        model->resistance += 0.5f;
+                    if(model->selected == 2 && model->resistance_index < 79) {
                         model->resistance_index++;
                     }
                 },
@@ -700,16 +687,13 @@ static bool combo_view_cracker_input_callback(InputEvent* event, void* context) 
                 app->view_cracker,
                 ComboLockCrackerModel * model,
                 {
-                    if(model->selected == 0 && model->first_lock > 0) {
-                        model->first_lock--;
+                    if(model->selected == 0 && model->first_lock_index > 0) {
                         model->first_lock_index--;
                     }
-                    if(model->selected == 1 && model->second_lock > 0) {
-                        model->second_lock--;
+                    if(model->selected == 1 && model->second_lock_index > 0) {
                         model->second_lock_index--;
                     }
-                    if(model->selected == 2 && model->resistance > 0) {
-                        model->resistance -= 0.5f;
+                    if(model->selected == 2 && model->resistance_index > 0) {
                         model->resistance_index--;
                     }
                 },
@@ -720,16 +704,13 @@ static bool combo_view_cracker_input_callback(InputEvent* event, void* context) 
                 app->view_cracker,
                 ComboLockCrackerModel * model,
                 {
-                    if(model->selected == 0 && model->first_lock < 39) {
-                        model->first_lock++;
+                    if(model->selected == 0 && model->first_lock_index < 39) {
                         model->first_lock_index++;
                     }
-                    if(model->selected == 1 && model->second_lock < 39) {
-                        model->second_lock++;
+                    if(model->selected == 1 && model->second_lock_index < 39) {
                         model->second_lock_index++;
                     }
-                    if(model->selected == 2 && model->resistance < 39.5f) {
-                        model->resistance += 0.5f;
+                    if(model->selected == 2 && model->resistance_index < 79) {
                         model->resistance_index++;
                     }
                 },
@@ -808,9 +789,6 @@ static ComboLockCrackerApp* combo_app_alloc() {
     view_allocate_model(app->view_cracker, ViewModelTypeLockFree, sizeof(ComboLockCrackerModel));
 
     ComboLockCrackerModel* model = view_get_model(app->view_cracker);
-    model->first_lock = 7;
-    model->second_lock = 14;
-    model->resistance = 13.0f;
     model->first_lock_index = 7;
     model->second_lock_index = 14;
     model->resistance_index = 26;

--- a/combo_cracker.c
+++ b/combo_cracker.c
@@ -36,6 +36,55 @@ typedef enum {
     ComboSubmenuIndexAbout,
 } ComboSubmenuIndex;
 
+typedef enum _ComboLockType {
+    ComboLockTypeNumeric = 0, // zero-init == numeric as default
+    ComboLockTypeAlphabetic
+} ComboLockType;
+
+// store as array of fixed-length strings, so don't need to store 80x pointer values in RAM.
+#define LOCK_INDEX_COUNT       (40u)
+#define RESISTANCE_INDEX_COUNT (80u)
+static const char gc_resistance_strings_numeric[RESISTANCE_INDEX_COUNT][5u] = {
+    "0.0",  "0.5",  "1.0",  "1.5",  "2.0",  "2.5",  "3.0",  "3.5",  "4.0",  "4.5",  "5.0",  "5.5",
+    "6.0",  "6.5",  "7.0",  "7.5",  "8.0",  "8.5",  "9.0",  "9.5",  "10.0", "10.5", "11.0", "11.5",
+    "12.0", "12.5", "13.0", "13.5", "14.0", "14.5", "15.0", "15.5", "16.0", "16.5", "17.0", "17.5",
+    "18.0", "18.5", "19.0", "19.5", "20.0", "20.5", "21.0", "21.5", "22.0", "22.5", "23.0", "23.5",
+    "24.0", "24.5", "25.0", "25.5", "26.0", "26.5", "27.0", "27.5", "28.0", "28.5", "29.0", "29.5",
+    "30.0", "30.5", "31.0", "31.5", "32.0", "32.5", "33.0", "33.5", "34.0", "34.5", "35.0", "35.5",
+    "36.0", "36.5", "37.0", "37.5", "38.0", "38.5", "39.0", "39.5",
+};
+static const char gc_lock_strings_numeric[LOCK_INDEX_COUNT][3u] = {
+    "0",  "1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9",  "10", "11", "12", "13",
+    "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27",
+    "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39",
+};
+#if 1 // pragma region // static const char gc_howto_numeric[]
+static const char gc_howto_numeric[] =
+    "How to use:\n"
+    "---\n"
+    "First lock value:\n"
+    "Set the lock's position to 0, then pull up firmly on the shackle and "
+    "slowly rotate the dial counter-clockwise until it catches between two "
+    "numbers. If the two locations where the lock gets caught between are "
+    "whole numbers, reduce the tension on the shackle slightly so you can "
+    "move out of the groove and find the next one. Once you find a groove "
+    "between two half numbers, enter the number in the middle of that groove "
+    "as the first lock position.\n\n"
+    "Second lock value:\n"
+    "Use the same process to find the next groove(s) after the first "
+    "position. Remember that the locations where the lock gets caught "
+    "between should be half numbers, so the middle location will be a "
+    "whole number.\n\n"
+    "Resistance value:\n"
+    "Now apply about half as much tension on the shackle and rotate the dial "
+    "CLOCKWISE until you feel resistance. You can repeat this step several "
+    "times to make sure you have the correct position. Then enter this value "
+    "as the resistance position. This can be a whole or half number.\n\n"
+    "This is a brief summary of the technique developed by Samy Kamkar. "
+    "For full details and his original write-up, see:\n"
+    "https://samy.pl/master/master.html\n";
+#endif // 1 pragma endregion // static const char* gc_howto_numeric[]
+
 typedef struct {
     ViewDispatcher* view_dispatcher;
     NotificationApp* notifications;
@@ -49,121 +98,320 @@ typedef struct {
 } ComboLockCrackerApp;
 
 typedef struct {
-    int first_lock;
-    int second_lock;
-    float resistance;
-    int selected;
-    char result[256];
+    ComboLockType lock_type;
+    int first_lock; // to be removed...
+    int second_lock; // to be removed...
+    float resistance; // to be removed...
+
+    unsigned int first_lock_index; //  Index into gc_lock_string_*
+    unsigned int second_lock_index; // Index into gc_lock_string_*
+    unsigned int resistance_index; //  Index into gc_resistance_string_*
+
+    int selected; // tracks which UI element is currently selected?
+    char result[256]; // this is string buffer for UI display of the result ... not the result itself.
 } ComboLockCrackerModel;
 
+typedef struct {
+    unsigned int second_pin_count; // variable number of pins for second digit [1..MAX_VALUES]
+    unsigned int third_pin_count; // variable number of pins for third digit   [1..MAX_VALUES]
+    unsigned int first_pin_index; // first pin is directly calculated (no guesswork)
+    unsigned int second_pin_index[MAX_VALUES]; // up to MAX_VALUES entries
+    unsigned int third_pin_index[MAX_VALUES]; //  up to MAX_VALUES entries
+} ComboLockCombination;
+
 /**
- * @brief      helper to convert float to string
- * @param      num   the float number to convert
+ * @brief      helper to get string for the resistance value
+ * @param      model   the ComboLockCrackerModel to obtain resistance value for
  * @return     string representation of the float
  */
-static char* float_to_char(float num) {
-    static char buffer[8];
-    snprintf(buffer, sizeof(buffer), "%.1f", (double)num);
-    return buffer;
+
+static const char* lock1_from_model(const ComboLockCrackerModel* model) {
+    return gc_lock_strings_numeric[model->first_lock_index];
+}
+static const char* lock2_from_model(const ComboLockCrackerModel* model) {
+    return gc_lock_strings_numeric[model->second_lock_index];
+}
+static const char* resistance_from_model(const ComboLockCrackerModel* model) {
+    return gc_resistance_strings_numeric[model->resistance_index];
+}
+static const char* label_from_solution_index(const ComboLockCrackerModel* model, int index) {
+    (void)(model); // need this to swap based on current lock model
+    return gc_lock_strings_numeric[index];
 }
 
-/**
- * @brief      calculate the combination based on inputs
- * @param      model   the model containing input values
- */
-static void calculate_combo(ComboLockCrackerModel* model) {
-    float sticky_number = model->resistance;
-    int sticky_as_int = (int)sticky_number;
-
-    int first_digit;
-    if((sticky_number - sticky_as_int) == 0.0f) {
-        // first digit easy, resistance + 5... crazy world we live in
-        first_digit = sticky_as_int + 5;
-    } else {
-        first_digit = (int)(sticky_number + 5) + 1; // ceiling that biih... prob. a better way
+static int SolutionComparator(const ComboLockCombination* r1, const ComboLockCombination* r2) {
+    if((r1 == NULL) && (r2 == NULL)) {
+        // LOG A WARNING ... as this was likely unintentional
+        return 0;
+    }
+    if(r1 == NULL) {
+        return -1;
+    }
+    if(r2 == NULL) {
+        return 1;
     }
 
-    first_digit = first_digit % 40;
-    int remainder = first_digit % 4;
+    if(r1->second_pin_count != r2->second_pin_count) {
+        return r1->second_pin_count - r2->second_pin_count;
+    }
+    if(r1->third_pin_count != r2->third_pin_count) {
+        return r1->third_pin_count - r2->third_pin_count;
+    }
+    if(r1->first_pin_index != r2->first_pin_index) {
+        return r1->first_pin_index - r2->first_pin_index;
+    }
+    for(unsigned int i = 0; i < r1->second_pin_count; ++i) {
+        if(r1->second_pin_index[i] != r2->second_pin_index[i]) {
+            return r1->second_pin_index[i] - r2->second_pin_index[i];
+        }
+    }
+    for(unsigned int i = 0; i < r1->third_pin_count; ++i) {
+        if(r1->third_pin_index[i] != r2->third_pin_index[i]) {
+            return r1->third_pin_index[i] - r2->third_pin_index[i];
+        }
+    }
+    return 0;
+}
 
-    int a = model->first_lock;
-    int b = model->second_lock;
+static void
+    calculate_combination(const ComboLockCrackerModel* model, ComboLockCombination* result) {
+    // First things first... zero the result structure
+    memset(result, 0, sizeof(ComboLockCombination));
 
-    // third digit isn't too bad
-    int third_position_values[MAX_VALUES];
-    int third_count = 0;
+    // calculate first result (index == value for numeric combo locks)
+    if(true) {
+        // From old code:
+        //     For numeric locks (0..39):
+        //         If the resistance float value corresponds to a whole number:
+        //             the first digit is: (int(number) + 5)
+        //         Else:
+        //             round up:           (int(number) + 5) + 1
+        //
+        // Converting to calculations using resistance indices 0..79:
+        //     Get integer value:           (index / 2)
+        //     Is index for a Whole number: (index % 2u == 0u)
+        //
+        // Thus, the first digit is calculated as:
 
-    for(int i = 0; i < 3; i++) {
-        if(a % 4 == remainder) third_position_values[third_count++] = a;
-        if(b % 4 == remainder) third_position_values[third_count++] = b;
-        a = (a + 10) % 40;
-        b = (b + 10) % 40;
+        unsigned int pin0 = model->resistance_index / 2u;
+        if(model->resistance_index % 2u != 0u) {
+            pin0 += 6;
+        } else {
+            pin0 += 5;
+        }
+        pin0 %= LOCK_INDEX_COUNT;
+        result->first_pin_index = pin0;
     }
 
-    int row_1 = (remainder + 2) % 40;
-    int row_2 = (row_1 + 4) % 40;
+    unsigned int remainder = result->first_pin_index % 4;
 
-    int second_position_values[MAX_VALUES];
-    int second_count = 0;
-    second_position_values[second_count++] = row_1;
-    second_position_values[second_count++] = row_2;
+    // calculate the potential THIRD pins
+    if(true) {
+        unsigned int a = model->first_lock_index; //  index == value for numeric combo locks
+        unsigned int b = model->second_lock_index; // index == value for numeric combo locks
 
-    for(int i = 0; i < 4; i++) {
-        row_1 = (row_1 + 8) % 40;
-        row_2 = (row_2 + 8) % 40;
-        second_position_values[second_count++] = row_1;
-        second_position_values[second_count++] = row_2;
-    }
-
-    for(int i = 0; i < second_count - 1; i++) {
-        for(int j = i + 1; j < second_count; j++) {
-            if(second_position_values[i] > second_position_values[j]) {
-                int temp = second_position_values[i];
-                second_position_values[i] = second_position_values[j];
-                second_position_values[j] = temp;
+        // Third digit:
+        //    Check N, N+10, N+20, N+30 (for N is either of the two lock indices)
+        // If any of those (value % 4) == (first pin % 4),
+        // then it's a potential solution.
+        for(int i = 0; i < 3; i++) {
+            if(((a + (10 * i)) % 4) == remainder) {
+                result->third_pin_index[result->third_pin_count++] = a;
+            }
+            if(((b + (10 * i)) % 4) == remainder) {
+                result->third_pin_index[result->third_pin_count++] = b;
             }
         }
     }
 
-    int pos = 0;
-    int written = snprintf(
-        model->result + pos,
-        sizeof(model->result) - pos,
-        "First Pin: %d\nSecond Pin(s): ",
-        first_digit);
-    if(written < 0 || written >= (int)(sizeof(model->result) - pos)) return;
-    pos += written;
+    // calculate the potential SECOND pins
+    if(true) {
+        // first two possibilities: remainder + 2, remainder + 6
+        // Note that modulo here is redundant, as remainder is in range [0..3]
+        int row_1 = (remainder + 2) % LOCK_INDEX_COUNT;
+        int row_2 = (row_1 + 4) % LOCK_INDEX_COUNT;
+        result->second_pin_index[result->second_pin_count++] = row_1;
+        result->second_pin_index[result->second_pin_count++] = row_2;
 
-    for(int i = 0; i < second_count; i++) {
-        written = snprintf(
-            model->result + pos, sizeof(model->result) - pos, "%d", second_position_values[i]);
-        if(written < 0 || written >= (int)(sizeof(model->result) - pos)) return;
+        for(int i = 0; i < 4; i++) {
+            row_1 = (row_1 + 8) % LOCK_INDEX_COUNT;
+            row_2 = (row_2 + 8) % LOCK_INDEX_COUNT;
+            result->second_pin_index[result->second_pin_count++] = row_1;
+            result->second_pin_index[result->second_pin_count++] = row_2;
+        }
+    }
+    // O(n^2) sorting of second pin numbers ... but as n is small (~8) it's good enough
+    for(unsigned int i = 0; i < result->second_pin_count - 1; i++) {
+        // ensure smallest of all remaining values is in index i...
+        for(unsigned int j = i + 1; j < result->second_pin_count; j++) {
+            // by comparing against all the remaining indices
+            if(result->second_pin_index[i] > result->second_pin_index[j]) {
+                // swap the values so smallest value comes first
+                unsigned int temp = result->second_pin_index[i];
+                result->second_pin_index[i] = result->second_pin_index[j];
+                result->second_pin_index[j] = temp;
+            }
+        }
+    }
+}
+
+/**
+ * @brief      calculate the combination based on inputs, AND displays the results
+ * @param      model   the model containing input values
+ */
+static void calculate_combo(ComboLockCrackerModel* model) {
+    // For numeric locks (0..39):
+    //     If the resistance corresponds to a whole number,
+    //     then the first digit is: (int(number) + 5)
+    //     Otherwise round up:      (int(number) + 6)
+    // Converting to using indices 0..79:
+    //     Whole number from index: (index % 2u == 0u)
+    //     Index increases by:      (index + 10 + ((index % 2u == 0u) ? 0u : 1u)) % RESISTANCE_INDEX_COUNT
+
+    ComboLockCombination result2 = {};
+    ComboLockCombination result_new = {};
+    calculate_combination(model, &result_new);
+
+    if(true) {
+        int first_digit;
+        if(true) {
+            float sticky_number = model->resistance;
+            int sticky_as_int = (int)sticky_number;
+
+            if((sticky_number - sticky_as_int) == 0.0f) {
+                // first digit easy, numeric resistance + 5... crazy world we live in
+                first_digit = sticky_as_int + 5;
+            } else {
+                first_digit =
+                    (int)(sticky_number + 5) + 1; // ceiling that biih... prob. a better way
+            }
+
+            first_digit = first_digit % 40;
+        }
+
+        int remainder = first_digit % 4;
+        int a = model->first_lock;
+        int b = model->second_lock;
+
+        // third digit isn't too bad
+        int third_position_values[MAX_VALUES];
+        int third_count = 0;
+
+        for(int i = 0; i < 3; i++) {
+            if(a % 4 == remainder) third_position_values[third_count++] = a;
+            if(b % 4 == remainder) third_position_values[third_count++] = b;
+            a = (a + 10) % 40;
+            b = (b + 10) % 40;
+        }
+
+        int row_1 = (remainder + 2) % 40;
+        int row_2 = (row_1 + 4) % 40;
+
+        int second_position_values[MAX_VALUES];
+        int second_count = 0;
+        second_position_values[second_count++] = row_1;
+        second_position_values[second_count++] = row_2;
+
+        for(int i = 0; i < 4; i++) {
+            row_1 = (row_1 + 8) % 40;
+            row_2 = (row_2 + 8) % 40;
+            second_position_values[second_count++] = row_1;
+            second_position_values[second_count++] = row_2;
+        }
+
+        for(int i = 0; i < second_count - 1; i++) {
+            for(int j = i + 1; j < second_count; j++) {
+                if(second_position_values[i] > second_position_values[j]) {
+                    int temp = second_position_values[i];
+                    second_position_values[i] = second_position_values[j];
+                    second_position_values[j] = temp;
+                }
+            }
+        }
+
+        // STORE IN NEW STRUCTURE TO ALLOW SPLITTING THIS FUNCTION,
+        // ALLOWING TO COMPARING RESULTS, ETC.
+        result2.first_pin_index = first_digit;
+        result2.second_pin_count = second_count;
+        result2.third_pin_count = third_count;
+        for(int i = 0; i < second_count; ++i) {
+            result2.second_pin_index[i] = second_position_values[i];
+        }
+        for(int i = 0; i < third_count; ++i) {
+            result2.third_pin_index[i] = third_position_values[i];
+        }
+    }
+
+    ComboLockCombination* solution = &result2;
+
+    // COMPARE OLD VS. NEW RESULTS
+    if(0 != SolutionComparator(&result2, &result_new)) {
+        // LOG AN ERROR ... the new computation is giving a different result!
+    }
+
+    // BEGIN DISPLAY OF ABOVE-CALCULATED RESULTS
+    int pos = 0;
+    if(true) {
+        const char* s = label_from_solution_index(model, solution->first_pin_index);
+        int written = snprintf(
+            model->result + pos, sizeof(model->result) - pos, "First Pin: %s\nSecond Pin(s): ", s);
+        if((written < 0) || (written >= (int)(sizeof(model->result) - pos))) {
+            // LOG ERROR -- ran out of buffer space before full solution output
+            return;
+        }
+        pos += written;
+    }
+
+    for(unsigned int i = 0; i < solution->second_pin_count; i++) {
+        const char* s = label_from_solution_index(model, solution->second_pin_index[i]);
+        int written = snprintf(model->result + pos, sizeof(model->result) - pos, "%s", s);
+        if(written < 0 || written >= (int)(sizeof(model->result) - pos)) {
+            // LOG ERROR -- ran out of buffer space before full solution output
+            return;
+        }
         pos += written;
 
-        if(i < second_count - 1) {
+        // append a comma if there are still more items (and `\n` after third result)
+        if(i < solution->second_pin_count - 1) {
             const char* sep = (i == 3) ? ",\n -> " : ", ";
             written = snprintf(model->result + pos, sizeof(model->result) - pos, "%s", sep);
-            if(written < 0 || written >= (int)(sizeof(model->result) - pos)) return;
+            if(written < 0 || written >= (int)(sizeof(model->result) - pos)) {
+                // LOG ERROR -- ran out of buffer space before full solution output
+                return;
+            }
             pos += written;
         }
     }
 
-    written = snprintf(model->result + pos, sizeof(model->result) - pos, "\nThird Pin(s): ");
-    if(written < 0 || written >= (int)(sizeof(model->result) - pos)) return;
-    pos += written;
+    if(true) {
+        int written =
+            snprintf(model->result + pos, sizeof(model->result) - pos, "\nThird Pin(s): ");
+        if((written < 0) || (written >= (int)(sizeof(model->result) - pos))) {
+            // LOG ERROR -- ran out of buffer space before full solution output
+            return;
+        }
+        pos += written;
+    }
 
-    for(int i = 0; i < third_count; i++) {
-        written = snprintf(
-            model->result + pos, sizeof(model->result) - pos, "%d", third_position_values[i]);
-        if(written < 0 || written >= (int)(sizeof(model->result) - pos)) return;
+    for(unsigned int i = 0; i < solution->third_pin_count; i++) {
+        const char* s = label_from_solution_index(model, solution->third_pin_index[i]);
+        int written = snprintf(model->result + pos, sizeof(model->result) - pos, "%s", s);
+        if((written < 0) || (written >= (int)(sizeof(model->result) - pos))) {
+            // LOG ERROR -- ran out of buffer space before full solution output
+            return;
+        }
         pos += written;
 
-        if(i < third_count - 1) {
+        if(i < solution->third_pin_count - 1) {
             written = snprintf(model->result + pos, sizeof(model->result) - pos, ", ");
-            if(written < 0 || written >= (int)(sizeof(model->result) - pos)) return;
+            if((written < 0) || (written >= (int)(sizeof(model->result) - pos))) {
+                // LOG ERROR -- ran out of buffer space before full solution output
+                return;
+            }
             pos += written;
         }
     }
+    return;
 }
 
 /**
@@ -232,7 +480,7 @@ static void combo_view_cracker_draw_callback(Canvas* canvas, void* model) {
     int indicator_offset = -5;
 
     canvas_draw_str(canvas, text_x, 12, "First Lock:");
-    snprintf(buf, sizeof(buf), "%d", my_model->first_lock);
+    snprintf(buf, sizeof(buf), "%s", lock1_from_model(my_model));
     canvas_draw_str(
         canvas,
         value_x + (my_model->selected == 0 ? indicator_offset : 0),
@@ -241,7 +489,7 @@ static void combo_view_cracker_draw_callback(Canvas* canvas, void* model) {
     canvas_draw_str(canvas, value_x, 12, buf);
 
     canvas_draw_str(canvas, text_x, 24, "Second Lock:");
-    snprintf(buf, sizeof(buf), "%d", my_model->second_lock);
+    snprintf(buf, sizeof(buf), "%s", lock2_from_model(my_model));
     canvas_draw_str(
         canvas,
         value_x + (my_model->selected == 1 ? indicator_offset : 0),
@@ -250,7 +498,7 @@ static void combo_view_cracker_draw_callback(Canvas* canvas, void* model) {
     canvas_draw_str(canvas, value_x, 24, buf);
 
     canvas_draw_str(canvas, text_x, 36, "Resistance:");
-    snprintf(buf, sizeof(buf), "%s", float_to_char(my_model->resistance));
+    snprintf(buf, sizeof(buf), "%s", resistance_from_model(my_model));
     canvas_draw_str(
         canvas,
         value_x + (my_model->selected == 2 ? indicator_offset : 0),
@@ -294,9 +542,18 @@ static bool combo_view_cracker_input_callback(InputEvent* event, void* context) 
                 app->view_cracker,
                 ComboLockCrackerModel * model,
                 {
-                    if(model->selected == 0 && model->first_lock > 0) model->first_lock--;
-                    if(model->selected == 1 && model->second_lock > 0) model->second_lock--;
-                    if(model->selected == 2 && model->resistance > 0) model->resistance -= 0.5f;
+                    if(model->selected == 0 && model->first_lock > 0) {
+                        model->first_lock--;
+                        model->first_lock_index--;
+                    }
+                    if(model->selected == 1 && model->second_lock > 0) {
+                        model->second_lock--;
+                        model->second_lock_index--;
+                    }
+                    if(model->selected == 2 && model->resistance > 0) {
+                        model->resistance -= 0.5f;
+                        model->resistance_index -= 1;
+                    }
                 },
                 redraw);
             break;
@@ -305,10 +562,18 @@ static bool combo_view_cracker_input_callback(InputEvent* event, void* context) 
                 app->view_cracker,
                 ComboLockCrackerModel * model,
                 {
-                    if(model->selected == 0 && model->first_lock < 39) model->first_lock++;
-                    if(model->selected == 1 && model->second_lock < 39) model->second_lock++;
-                    if(model->selected == 2 && model->resistance < 39.5f)
+                    if(model->selected == 0 && model->first_lock < 39) {
+                        model->first_lock++;
+                        model->first_lock_index++;
+                    }
+                    if(model->selected == 1 && model->second_lock < 39) {
+                        model->second_lock++;
+                        model->second_lock_index++;
+                    }
+                    if(model->selected == 2 && model->resistance < 39.5f) {
                         model->resistance += 0.5f;
+                        model->resistance_index++;
+                    }
                 },
                 redraw);
             break;
@@ -318,16 +583,25 @@ static bool combo_view_cracker_input_callback(InputEvent* event, void* context) 
         default:
             break;
         }
-    } else if (event->type == InputTypeRepeat) {
+    } else if(event->type == InputTypeRepeat) {
         switch(event->key) {
         case InputKeyLeft:
             with_view_model(
                 app->view_cracker,
                 ComboLockCrackerModel * model,
                 {
-                    if(model->selected == 0 && model->first_lock > 0) model->first_lock--;
-                    if(model->selected == 1 && model->second_lock > 0) model->second_lock--;
-                    if(model->selected == 2 && model->resistance > 0) model->resistance -= 0.5f;
+                    if(model->selected == 0 && model->first_lock > 0) {
+                        model->first_lock--;
+                        model->first_lock_index--;
+                    }
+                    if(model->selected == 1 && model->second_lock > 0) {
+                        model->second_lock--;
+                        model->second_lock_index--;
+                    }
+                    if(model->selected == 2 && model->resistance > 0) {
+                        model->resistance -= 0.5f;
+                        model->resistance_index--;
+                    }
                 },
                 redraw);
             break;
@@ -336,10 +610,18 @@ static bool combo_view_cracker_input_callback(InputEvent* event, void* context) 
                 app->view_cracker,
                 ComboLockCrackerModel * model,
                 {
-                    if(model->selected == 0 && model->first_lock < 39) model->first_lock++;
-                    if(model->selected == 1 && model->second_lock < 39) model->second_lock++;
-                    if(model->selected == 2 && model->resistance < 39.5f)
+                    if(model->selected == 0 && model->first_lock < 39) {
+                        model->first_lock++;
+                        model->first_lock_index++;
+                    }
+                    if(model->selected == 1 && model->second_lock < 39) {
+                        model->second_lock++;
+                        model->second_lock_index++;
+                    }
+                    if(model->selected == 2 && model->resistance < 39.5f) {
                         model->resistance += 0.5f;
+                        model->resistance_index++;
+                    }
                 },
                 redraw);
             break;
@@ -397,8 +679,10 @@ static ComboLockCrackerApp* combo_app_alloc() {
     view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
 
     app->submenu = submenu_alloc();
-    submenu_add_item(app->submenu, "Crack Lock", ComboSubmenuIndexCracker, combo_submenu_callback, app);
-    submenu_add_item(app->submenu, "Tutorial", ComboSubmenuIndexTutorial, combo_submenu_callback, app);
+    submenu_add_item(
+        app->submenu, "Crack Lock", ComboSubmenuIndexCracker, combo_submenu_callback, app);
+    submenu_add_item(
+        app->submenu, "Tutorial", ComboSubmenuIndexTutorial, combo_submenu_callback, app);
     submenu_add_item(app->submenu, "About", ComboSubmenuIndexAbout, combo_submenu_callback, app);
     view_set_previous_callback(submenu_get_view(app->submenu), combo_navigation_exit_callback);
     view_dispatcher_add_view(
@@ -417,6 +701,9 @@ static ComboLockCrackerApp* combo_app_alloc() {
     model->first_lock = 0;
     model->second_lock = 0;
     model->resistance = 0.0f;
+    model->first_lock_index = 0;
+    model->second_lock_index = 0;
+    model->resistance_index = 0;
     model->selected = 0;
     model->result[0] = '\0';
 
@@ -429,22 +716,7 @@ static ComboLockCrackerApp* combo_app_alloc() {
         app->view_dispatcher, ComboViewResults, widget_get_view(app->widget_results));
 
     app->widget_tutorial = widget_alloc();
-    widget_add_text_scroll_element(
-        app->widget_tutorial,
-        0,
-        0,
-        128,
-        64,
-        "How to use:\n"
-        "---\n"
-        "First lock value:\n"
-        "Set the lock's position to 0, then pull up firmly on the shackle and slowly rotate the dial counter-clockwise until it catches between two numbers. If the two locations where the lock gets caught between are whole numbers, reduce the tension on the shackle slightly so you can move out of the groove and find the next one. Once you find a groove between two half numbers, enter the number in the middle of that groove as the first lock position.\n\n"
-        "Second lock value:\n"
-        "Use the same process to find the next groove(s) after the first position. Remember that the locations where the lock gets caught between should be half numbers, so the middle location will be a whole number.\n\n"
-        "Resistance value:\n"
-        "Now apply about half as much tension on the shackle and rotate the dial clockwise until you feel resistance. You can repeat this step several times to make sure you have the correct position. Then enter this value as the resistance position. This can be a whole or half number.\n\n"
-        "This is a brief summary of the technique developed by Samy Kamkar. For full details and his original write-up, see:\n"
-        "https://samy.pl/master/master.html\n");
+    widget_add_text_scroll_element(app->widget_tutorial, 0, 0, 128, 64, gc_howto_numeric);
     view_set_previous_callback(
         widget_get_view(app->widget_tutorial), combo_navigation_submenu_callback);
     view_dispatcher_add_view(


### PR DESCRIPTION
Fixes #3 

## DRAFT -- For review / comment only.

I will open a new PR after fixing the last bits.

This is 90% done ... can select at compilation time the default lock type.

When compiled for alphabetic locks, all values can be entered accordingly, solution is properly calculated, and solution is displayed with alphabetic labels.

Todo: add a UI element to switch between the two lock types dynamically.  Should be very, very simple.

Todo: optionally, warn if values entered result in solutions that use half-letter positions.

Huzzah!